### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/gils0519/bd2c0033-c28c-4305-8423-fa776c85ec11/f694fc70-1b4e-416c-8736-2bb758ddbe3c/_apis/work/boardbadge/0c891a1a-7b62-4e69-894d-fcbb10223dbd)](https://dev.azure.com/gils0519/bd2c0033-c28c-4305-8423-fa776c85ec11/_boards/board/t/f694fc70-1b4e-416c-8736-2bb758ddbe3c/Microsoft.RequirementCategory)
 # camera-app
 Super awesome camera web app built with HTML, CSS, and JS.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/gils0519/bd2c0033-c28c-4305-8423-fa776c85ec11/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.